### PR TITLE
bump time upper bound for GHC 7.10

### DIFF
--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -56,7 +56,7 @@ Library
       else
         build-depends: directory == 1.1.*
     else
-      build-depends: time >= 1.0 && < 1.5
+      build-depends: time >= 1.0 && < 1.6
       build-depends: directory >= 1.2 && < 1.3
 
     other-modules:


### PR DESCRIPTION
GHC 7.10 ships with `time-1.5.0.1`, this makes it compile.
