### PR TITLE
Fixed isSymbolicLink ambiguity

### DIFF
--- a/src/System/PosixCompat/Files.hsc
+++ b/src/System/PosixCompat/Files.hsc
@@ -120,7 +120,7 @@ import Control.Exception (bracket)
 import Control.Monad (liftM, liftM2)
 import Data.Bits ((.|.), (.&.))
 import Prelude hiding (read)
-import System.Directory
+import System.Directory hiding (isSymbolicLink)
 import System.IO (IOMode(..), openFile, hFileSize, hSetFileSize, hClose)
 import System.IO.Error
 import System.PosixCompat.Types


### PR DESCRIPTION
Fixed building on Win 10 x64 with ghc-8.0.1:

    [8 of 9] Compiling System.PosixCompat.Files ( dist\build\System\PosixCompat\Files.hs, dist\build\System\PosixCompat\Files.o )

    srcSystemPosixCompatFiles.hsc:67:7: error:
        Ambiguous occurrence `isSymbolicLink'
        It could refer to either `System.Directory.isSymbolicLink',
                                 imported from `System.Directory' at srcSystemPosixCompatFiles.hsc:123:1-47
                              or `System.PosixCompat.Files.isSymbolicLink',
                                 defined at srcSystemPosixCompatFiles.hsc:293:1