### PR TITLE
Fix FILETIME calculation on Windows 32 Bit.

### DIFF
--- a/src/System/PosixCompat/Files.hsc
+++ b/src/System/PosixCompat/Files.hsc
@@ -433,7 +433,7 @@ setFileTimes file atime mtime =
     epochTimeToFileTime (CTime t) = FILETIME (fromIntegral ll)
       where
         ll :: Int64
-        ll = t * 10000000 + 116444736000000000
+        ll = fromIntegral t * 10000000 + 116444736000000000
 
 touchFile :: FilePath -> IO ()
 touchFile name =


### PR DESCRIPTION
t seems to be Int32 instead of Int64 here.