### PR TITLE
Allow building with directory-1.3.0.0

### DIFF
--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -57,7 +57,7 @@ Library
         build-depends: directory == 1.1.*
     else
       build-depends: time >= 1.0 && < 1.7
-      build-depends: directory >= 1.2 && < 1.3
+      build-depends: directory >= 1.2 && < 1.4
 
     other-modules:
       System.PosixCompat.Internal.Time


### PR DESCRIPTION
GHC 8.0.2 ships with `directory-1.3.0.0`, for which `unix-compat`'s upper version bounds (`< 1.3`) are too tight. The only API-breaking change in `directory-1.3.0.0` involves `canonicalizePath`, which `unix-compat` doesn't use, so this bound can be relaxed.