### PR TITLE
fix build with Win32-2.6.0

### DIFF
--- a/src/System/PosixCompat/Files.hsc
+++ b/src/System/PosixCompat/Files.hsc
@@ -392,7 +392,11 @@ readSymbolicLink _ = unsupported "readSymbolicLink"
 -- Renaming
 
 rename :: FilePath -> FilePath -> IO ()
+#if MIN_VERSION_Win32(2, 6, 0)
+rename name1 name2 = moveFileEx name1 (Just name2) mOVEFILE_REPLACE_EXISTING
+#else
 rename name1 name2 = moveFileEx name1 name2 mOVEFILE_REPLACE_EXISTING
+#endif
 
 -- -----------------------------------------------------------------------------
 -- chown()


### PR DESCRIPTION
My earlier change to rename broke building with the new version of
Win32, which has a Maybe FilePath as the second moveFileEx parameter.

Fixes #35 