### PR TITLE
Fixed compilation with GHC 8.6.1-alpha2

### DIFF
--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -63,7 +63,7 @@ Library
       System.PosixCompat.Internal.Time
 
   else
-    build-depends: unix >= 2.4 && < 2.8
+    build-depends: unix >= 2.4 && < 2.9
     include-dirs: include
     includes: HsUnixCompat.h
     install-includes: HsUnixCompat.h


### PR DESCRIPTION
GHC 8.6.1-alpha2 was [announced](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-July/026776.html). This PR fix the compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/3160.