### PR TITLE
Include new header for major/minor/makedev macros.

### DIFF
--- a/cbits/HsUnixCompat.c
+++ b/cbits/HsUnixCompat.c
@@ -2,6 +2,8 @@
 
 #ifdef SOLARIS
 #include <sys/mkdev.h>
+#elif defined(__GLIBC__)
+#include <sys/sysmacros.h>
 #endif
 
 unsigned int unix_major(dev_t dev)


### PR DESCRIPTION
In glibc 2.25, these macros as provided via sys/types.h are now deprecated. The correct header is now sys/sysmacros.h.

See https://sourceware.org/glibc/wiki/Release/2.25#Packaging_Changes